### PR TITLE
Request debug and indent macro declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can generate a PDF or an HTML copy of this guide using
 * [Naming](#naming)
 * [Strings](#strings)
 * [Macros](#macros)
+    * [Macro Declarations](#macro-declarations)
 * [Comments](#comments)
     * [Comment Annotations](#comment-annotations)
 * [Existential](#existential)
@@ -329,6 +330,24 @@ name clashes.
   composability.
 
 * Prefer syntax-quoted forms over building lists manually.
+
+### Macro Declarations
+
+* Always declare the [debug-specification](http://www.gnu.org/software/emacs/manual/html_node/elisp/Specification-List.html#Specification-List),
+  this tells edebug which arguments are meant for evaluation. If all
+  arguments are evaluated, a simple `(declare (debug t))` is enough.
+
+* Declare the [indent specification](https://www.gnu.org/software/emacs/manual/html_node/elisp/Indenting-Macros.html#Indenting-Macros)
+  if the macro arguments should not be aligned like a function (think
+  of `defun` or `with-current-buffer`).
+
+    ```el
+    (defmacro define-widget (name &rest forms)
+      "Description"
+      (declare (debug (sexp body))
+               (indent defun))
+      ...)
+    ```
 
 ## Comments
 


### PR DESCRIPTION
Add a subsection to Macros which requests indent declarations when
necessary, and debug declarations always.

edebug's default behavior is to assume "no arguments are evaluated", which is probably the opposite of the most common case. So it seems fit that every macro should declare whether its arguments are meant for instrumentation.

I believe this would be a good addition to the guide. Debug and indent are, by far, the most used declarations and they make for a better experience when people are making use of the macro.

Let me know if you think it's too long, kinda wrong, or just plain rubbish.
