### PR TITLE
Correct "issues" link.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ try to follow these guidelines when you do so.
 * Open a [pull request][4] that relates to *only* one subject with a clear title
   and description in grammatically correct, complete sentences.
 
-[1]: https://github.com/bbatsov/clojure-style-guide/issues
+[1]: https://github.com/bbatsov/emacs-lisp-style-guide/issues
 [2]: http://gun.io/blog/how-to-github-fork-branch-and-pull-request
 [3]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [4]: https://help.github.com/articles/using-pull-requests


### PR DESCRIPTION
Previously, this linked to the Clojure style guide.
